### PR TITLE
解决 debian 12 安装玲珑  GPG 错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 cache
 dist
+.idea

--- a/en/guide/start/install.md
+++ b/en/guide/start/install.md
@@ -68,7 +68,10 @@ sudo apt install linglong-builder linglong-box linglong-bin
 Add Linglong repository source.
 
 ```bash
-sudo bash -c "echo 'deb [trusted=yes] https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/ ./' > /etc/apt/sources.list.d/linglong.list"
+sudo apt install -y apt-transport-https ca-certificates curl gpg
+sudo mkdir -p /etc/apt/keyrings/
+curl -fsSL https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/linglong-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/linglong-apt-keyring.gpg] https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 ```
 
 Update the repository and install Linglong.

--- a/en/guide/start/install.md
+++ b/en/guide/start/install.md
@@ -68,7 +68,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 Add Linglong repository source.
 
 ```bash
-sudo apt install -y apt-transport-https ca-certificates curl gpg
+sudo apt install -y apt-transport-https ca-certificates curl gpg xdg-utils
 sudo mkdir -p /etc/apt/keyrings/
 curl -fsSL https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/linglong-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/linglong-apt-keyring.gpg] https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list

--- a/guide/start/install.md
+++ b/guide/start/install.md
@@ -68,7 +68,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 添加玲珑仓库源。
 
 ```bash
-sudo apt install -y apt-transport-https ca-certificates curl gpg
+sudo apt install -y apt-transport-https ca-certificates curl gpg xdg-utils
 sudo mkdir -p /etc/apt/keyrings/
 curl -fsSL https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/linglong-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/linglong-apt-keyring.gpg] https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list

--- a/guide/start/install.md
+++ b/guide/start/install.md
@@ -68,7 +68,10 @@ sudo apt install linglong-builder linglong-box linglong-bin
 添加玲珑仓库源。
 
 ```bash
-sudo bash -c "echo 'deb [trusted=yes] https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/ ./' > /etc/apt/sources.list.d/linglong.list"
+sudo apt install -y apt-transport-https ca-certificates curl gpg
+sudo mkdir -p /etc/apt/keyrings/
+curl -fsSL https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/linglong-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/linglong-apt-keyring.gpg] https://download.opensuse.org/repositories/home:/kamiyadm/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 ```
 
 更新仓库并安装玲珑。


### PR DESCRIPTION
fix  debian 12.  GPG error
![image](https://github.com/user-attachments/assets/7018160f-28e2-4564-b5df-4af60288f040)



快速验证：
```shell
# 用容器快速验证
docker run --rm --name debian-dev -d --init debian:12

```